### PR TITLE
Allow to skip regex compilation in get_validation_dict

### DIFF
--- a/i18naddress/__init__.py
+++ b/i18naddress/__init__.py
@@ -58,8 +58,11 @@ class I18nCountryData(object):
             area_choices_prefix + '_choices': sub_area_choices,
             area_choices_prefix + '_keys': sub_area_keys}
         if 'zip' in country_data:
-            validation_data['postal_code_regexp'] = re.compile(
-                country_data['zip'], re.IGNORECASE)
+            if kwargs.get('parse_zip_regex', True):
+                zip_regexp = re.compile(country_data['zip'], re.IGNORECASE)
+            else:
+                zip_regexp = country_data['zip']
+            validation_data['postal_code_regexp'] = zip_regexp
         if 'zipex' in country_data:
             validation_data['postal_code_example'] = country_data['zipex']
         if 'require' in country_data:

--- a/tests/test_i18naddress.py
+++ b/tests/test_i18naddress.py
@@ -60,17 +60,22 @@ def test_iterator():
     assert keys == ['US']
 
 
-@pytest.mark.parametrize('validation_args, validation_data', [
-    (('PL',), {'sub_area_keys': ['D', 'L'],
+@pytest.mark.parametrize('validation_args, validation_kwargs, validation_data', [
+    (('PL',), {}, {'sub_area_keys': ['D', 'L'],
                'require': ('street_address', 'city', 'postal_code'),
                'postal_code_regexp': re.compile(
                    PL_DATA['PL']['zip'], re.IGNORECASE),
                'sub_area_choices': [('D', 'Lower Silesian'), ('L', 'Lublin')]}),
-    (('PL', 'D'), {'sub_area_keys': [], 'sub_area_choices': [],
+    (('PL', 'D'), {}, {'sub_area_keys': [], 'sub_area_choices': [],
                    'postal_code_regexp': re.compile(
                        PL_DATA['PL']['zip'], re.IGNORECASE),
+                   'postal_code_example': '58-580',}),
+    (('PL', 'D'), {'parse_zip_regex': False}, {'sub_area_keys': [],
+                   'sub_area_choices': [],
+                   'postal_code_regexp': PL_DATA['PL']['zip'],
                    'postal_code_example': '58-580',})
 ])
-def test_get_validation_dict(validation_args, validation_data):
+def test_get_validation_dict(validation_args, validation_kwargs, validation_data):
     i18n_data = I18nCountryData()
-    assert i18n_data.get_validation_dict(*validation_args) == validation_data
+    assert i18n_data.get_validation_dict(
+        *validation_args, **validation_kwargs) == validation_data


### PR DESCRIPTION
It's useful when you want to serialize validation dict. `re` objects are not serializable.