### PR TITLE
Use country_code instead of country

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -169,7 +169,7 @@ Used with Django form
                 country_code, country_area, city,
                 city_area, postal_code, street_address)
 
-            if 'country' in errors:
+            if 'country_code' in errors:
                 self.add_error('country', _(
                     '%s is not supported country code.' % country_code))
             if 'street_address' in errors:

--- a/i18naddress/__init__.py
+++ b/i18naddress/__init__.py
@@ -84,7 +84,7 @@ def validate_areas(country_code, country_area=None, city=None, city_area=None,
     try:
         i18n_country_data = I18nCountryData(country_code)
     except ValueError:
-        errors['country'] = 'invalid'
+        errors['country_code'] = 'invalid'
     else:
         validation_data.update(i18n_country_data.get_validation_dict(
             country_code, sub_area_prefix='country_area'))

--- a/tests/test_validate_areas.py
+++ b/tests/test_validate_areas.py
@@ -30,7 +30,7 @@ def save_test_data(tmpdir):
 
 
 @pytest.mark.parametrize('kwargs, errors', [
-    ({'country_code': 'DE'}, {'country': 'invalid'}),
+    ({'country_code': 'DE'}, {'country_code': 'invalid'}),
     ({'country_code': 'AR'},
      {'country_area': 'required', 'city': 'required', 'city_area': 'required',
       'postal_code': 'required', 'street_address': 'required'}),


### PR DESCRIPTION
`validate_areas()` method expects `country_code` as an argument. If it's invalid it raises an error in `country` field.
My change will make `validate_areas()`  more consistent and it will raise the error in `country_code` field as it's expected.
