### PR TITLE
setup: fix encoding handling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ class DownloadJSONFiles(Command):
 
 
 def get_long_description():
-    with open('README.rst') as readme_file:
+    with open('README.rst', encoding='utf-8') as readme_file:
         readme = readme_file.read()
     # add GitHub badge in PyPi
     return readme.replace(


### PR DESCRIPTION
Error log:

```
Collecting google-i18n-address==2.0.1 (from -r requirements.txt (line 38))
  Using cached google-i18n-address-2.0.1.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-6pz4ptgy/google-i18n-address/setup.py", line 58, in <module>
        long_description=get_long_description(),
      File "/tmp/pip-build-6pz4ptgy/google-i18n-address/setup.py", line 50, in get_long_description
        readme = readme_file.read()
      File "/home/ubuntu/.virtualenvs/saleor/lib/python3.5/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe4 in position 3815: ordinal not in range(128)

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-6pz4ptgy/google-i18n-address/
```