### PR TITLE
Fix city area normalization and improve validation rules

### DIFF
--- a/tests/test_i18naddress.py
+++ b/tests/test_i18naddress.py
@@ -20,6 +20,31 @@ def test_dictionary_access():
     assert state['name'] == 'Nevada'
 
 
+def test_validation_rules_canada():
+    validation_data = get_validation_rules({'country_code': 'CA'})
+    assert validation_data.country_area_choices == [
+        ('AB', 'Alberta'),
+        ('BC', 'British Columbia'),
+        ('BC', 'Colombie-Britannique'),
+        ('MB', 'Manitoba'),
+        ('NB', 'New Brunswick'),
+        ('NB', 'Nouveau-Brunswick'),
+        ('NL', 'Newfoundland and Labrador'),
+        ('NL', 'Terre-Neuve-et-Labrador'),
+        ('NT', 'Northwest Territories'),
+        ('NT', 'Territoires du Nord-Ouest'),
+        ('NS', 'Nouvelle-Écosse'),
+        ('NS', 'Nova Scotia'),
+        ('NU', 'Nunavut'),
+        ('ON', 'Ontario'),
+        ('PE', 'Prince Edward Island'),
+        ('PE', 'Île-du-Prince-Édouard'),
+        ('QC', 'Quebec'),
+        ('QC', 'Québec'),
+        ('SK', 'Saskatchewan'),
+        ('YT', 'Yukon')]
+
+
 def test_validation_rules_switzerland():
     validation_data = get_validation_rules({'country_code': 'CH'})
     assert validation_data.allowed_fields == {

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -150,6 +150,22 @@ def test_address_latinization():
     address = latinize_address(address)
     assert address['country_area'] == 'California'
     address = {
+        'country_code': 'CN',
+        'country_area': '云南省',
+        'postal_code': '677400',
+        'city': '临沧市',
+        'city_area': '凤庆县',
+        'street_address': '中关村东路1号'}
+    address = latinize_address(address)
+    assert address == {
+        'country_code': 'CN',
+        'country_area': 'Yunnan Sheng',
+        'postal_code': '677400',
+        'city': 'Lincang Shi',
+        'city_area': 'Fengqing Xian',
+        'street_address': '中关村东路1号',
+        'sorting_code': ''}
+    address = {
         'name': 'Zhang San',
         'company_name': 'Beijing Kid Toy Company',
         'country_code': 'CN',


### PR DESCRIPTION
The normalization bug would use the city name for the city area. Caught this while working with addresses in China.

New validation rules are more useful for drop-downs and autocomplete.