### PR TITLE
Avoid build failure on rpmbuild 4.16

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ class DownloadJSONFiles(Command):
 
 def get_long_description():
     with io.open('README.rst', encoding='utf-8') as readme_file:
-        readme = readme_file.read()
+        readme = readme_file.read().replace("%", "%%")
     # add GitHub badge in PyPi
     return readme.replace(
         '|codecov.io| |Circle CI| |PyPi downloads| |requires.io| |PyPi version| |PyPi pythons|', #  noqa


### PR DESCRIPTION
Avoid build failure caused by "%S" in spec file, from README.rst
Fix by replacing "%" with "%%"