### PR TITLE
Drop encoding parameter from json.load

### DIFF
--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -45,7 +45,7 @@ def test_downloader_country(tmpdir, country, file_names, data):
     for file_name in file_names:
         assert data_dir.join(file_name).exists()
         assert json.load(
-            data_dir.join(file_name), encoding='utf-8') == data[file_name]
+            data_dir.join(file_name)) == data[file_name]
 
 
 def test_downloader_invalid_country():


### PR DESCRIPTION
Apparently this is no longer an accepted keyword for json.load(), as
of python 3.9.

This was uncovered in https://bugs.debian.org/973175 where the
google-i18n-address tests failed.  But i haven't been able to find a
reference for the change in python upstream.  Perhaps the encoding
parameter never did anything, but 3.9 became more strict about
unhandled keywords.

It looks like python's json module does bytestream encoding
autodetection anyway so this should be safe to do:
https://bugs.python.org/issue17909