### PR TITLE
Fix installing stray files into site-packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,6 @@ exclude = ["tests"]
 include = [
   "i18naddress/**/*.py",
   "i18naddress/**/*.json",
-  "LICENSE",
-  "README.rst",
-  "pyproject.toml",
 ]
 
 [project.urls]


### PR DESCRIPTION
Remove `pyproject.toml`, `README.rst` and `LICENSE` from `tool.hatch.build.include` to prevent them from being installed into site-packages where they don't belong.

These files are included in sdist archives unconditionally, so they do not need to be specified in any way.

Fixes #75